### PR TITLE
Use Ticks in place of clientID to avoid debug log file name clash

### DIFF
--- a/QuickFIXn/ClientHandlerThread.cs
+++ b/QuickFIXn/ClientHandlerThread.cs
@@ -61,7 +61,7 @@ namespace QuickFix
                 debugLogFilePath = settingsDict.GetString(SessionSettings.FILE_LOG_PATH);
 
             // FIXME - do something more flexible than hardcoding a filelog
-            log_ = new FileLog(debugLogFilePath, new SessionID("ClientHandlerThread", clientId.ToString(), "Debug"));
+            log_ = new FileLog(debugLogFilePath, new SessionID("ClientHandlerThread", DateTime.UtcNow.Ticks.ToString(), "Debug"));
 
             this.Id = clientId;
             socketReader_ = new SocketReader(tcpClient, socketSettings, this);


### PR DESCRIPTION
clientId can clash if there's more than one Acceptor endpoint listening on different IP or Port but trying to write to the same debug log file as all starting at 0.  

Using ticks to hopefully keep unique in between each client logon attempt.
